### PR TITLE
feat(register and join event): create model schema and function API

### DIFF
--- a/backend/src/controllers/event.controller.ts
+++ b/backend/src/controllers/event.controller.ts
@@ -1,13 +1,158 @@
 import { Request, Response } from "express";
+import Member from "../models/member.model";
+import Team from "../models/team.model";
+import TeamMembership from "../models/team.membership.model";
+import mongoose from "mongoose";
+import User from "../models/user.model";
 
-export const registerForEvent = async (req: Request, res: Response) => {
-    const userId = req.user?.userId;
-    
-    const { teamName, paymentProof } = req.body;
+// generate code
+const generateUniqueTeamCode = async (): Promise<string> => {
+    let teamCode: string = '';
+    let isExsits = false;
 
-    console.log(`User with ID ${userId} is registering team "${teamName}".`);
-
-    res.status(201).json({ message: "Successfully registered for the event!" });
+    while (!isExsits) {
+        const randomNumber = Math.floor(100000 + Math.random() * 900000);
+        teamCode = randomNumber.toString();
+        
+        const existingTeam = await Team.findOne({ teamCode });
+        
+        if (!existingTeam) {
+            isExsits = true;
+        }
+    }
+    return teamCode;
 };
 
-// ^^ hanya template code (untuk implement middleware), logic/schema cuman random
+export const registerForEvent = async (req: Request, res: Response) => {
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    try {
+        const { teamName, paymentProofUrl, teamMembers } = req.body;
+        const userId = req.user?.userId;
+        const userEmail = req.user?.email;
+
+        const existingMembership = await TeamMembership.findOne({ userId }).session(session);
+        if (existingMembership) {
+            await session.abortTransaction();
+            return res.status(409).json({ message: 'User sudah terdaftar di tim lain' });
+        }
+
+        const newTeamCode = await generateUniqueTeamCode();
+
+        const newTeam = new Team({
+            teamCode: newTeamCode,
+            teamName,
+            paymentProofUrl,
+            isPay: false,
+            isLock: false,
+            isQualified: false,
+            email: userEmail
+        });
+        await newTeam.save({ session });
+
+        const teamMembership = new TeamMembership({
+            teamCode: newTeam._id,
+            userId: userId
+        });
+        await teamMembership.save({ session });
+
+        const membersToInsert = teamMembers.map((member: any) => ({
+            ...member,
+            teamCode: newTeam._id
+        }));
+        await Member.insertMany(membersToInsert, { session });
+
+        await session.commitTransaction();
+        res.status(201).json({ 
+            message: 'Berhasil mendaftar untuk event', 
+            teamId: newTeam._id,
+            teamCode: newTeam.teamCode
+        });
+
+    } catch (error: any) {
+        await session.abortTransaction();
+        res.status(500).json({ message: 'Gagal mendaftar tim', error: error.message });
+    } finally {
+        session.endSession();
+    }
+};
+
+export const joinTeam = async (req: Request, res: Response) => {
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    try {
+        const { teamCode } = req.body;
+        const userId = req.user?.userId;
+        const userEmail = req.user?.email;
+
+        // dapetin data user
+        const user = await User.findOne({ email: userEmail }).session(session);
+
+        if (!teamCode) {
+            await session.abortTransaction();
+            return res.status(400).json({ message: 'Kode tim harus disediakan.' });
+        }
+
+        // dapetin data team
+        const team = await Team.findOne({ teamCode }).session(session);
+        if (!team) {
+            await session.abortTransaction();
+            return res.status(404).json({ message: 'Kode tim tidak ditemukan.' });
+        }
+
+        if (team.isLock) {
+            await session.abortTransaction();
+            return res.status(403).json({ message: 'Tim ini sudah dikunci dan tidak menerima anggota baru.' });
+        }
+
+        const existingGlobalMembership = await TeamMembership.findOne({ userId }).session(session);
+        if (existingGlobalMembership) {
+            await session.abortTransaction();
+            return res.status(409).json({ message: 'Anda sudah terdaftar di tim lain.' });
+        }
+
+        const existingTeamMember = await Member.findOne({ teamCode: team._id, email: userEmail }).session(session);
+        if (existingTeamMember) {
+             await session.abortTransaction();
+             return res.status(409).json({ message: 'Anda sudah menjadi anggota tim ini.' });
+        }
+
+        const newTeamMembership = new TeamMembership({
+            teamCode: team._id,
+            userId: userId
+        });
+        await newTeamMembership.save({ session });
+
+        const newMember = new Member({
+            teamCode: team._id,
+            email: userEmail,
+        });
+        await newMember.save({ session });
+        
+        // auto lock jika sudah 3 anggota
+        const MAX_TEAM_MEMBERS = 3;
+        const memberCounter = await Member.countDocuments({ teamCode: team._id }).session(session);
+
+        if (memberCounter >= MAX_TEAM_MEMBERS) {
+            if (!team.isLock) {
+                team.isLock = true;
+                await team.save({ session });
+            }
+        }
+
+        await session.commitTransaction();
+        res.status(200).json({
+            message: 'Berhasil bergabung ke tim',
+            teamName: team.teamName,
+            teamCode: team.teamCode
+        });
+
+    } catch (error: any) {
+        await session.abortTransaction();
+        res.status(500).json({ message: 'Gagal bergabung ke tim', error: error.message });
+    } finally {
+        session.endSession();
+    }
+};

--- a/backend/src/controllers/event.controller.ts
+++ b/backend/src/controllers/event.controller.ts
@@ -52,14 +52,14 @@ export const registerForEvent = async (req: Request, res: Response) => {
         await newTeam.save({ session });
 
         const teamMembership = new TeamMembership({
-            teamCode: newTeam._id,
+            teamId: newTeam._id,
             userId: userId
         });
         await teamMembership.save({ session });
 
         const membersToInsert = teamMembers.map((member: any) => ({
             ...member,
-            teamCode: newTeam._id
+            teamId: newTeam._id
         }));
         await Member.insertMany(membersToInsert, { session });
 
@@ -113,27 +113,27 @@ export const joinTeam = async (req: Request, res: Response) => {
             return res.status(409).json({ message: 'Anda sudah terdaftar di tim lain.' });
         }
 
-        const existingTeamMember = await Member.findOne({ teamCode: team._id, email: userEmail }).session(session);
+        const existingTeamMember = await Member.findOne({ teamId: team._id, email: userEmail }).session(session);
         if (existingTeamMember) {
              await session.abortTransaction();
              return res.status(409).json({ message: 'Anda sudah menjadi anggota tim ini.' });
         }
 
         const newTeamMembership = new TeamMembership({
-            teamCode: team._id,
+            teamId: team._id,
             userId: userId
         });
         await newTeamMembership.save({ session });
 
         const newMember = new Member({
-            teamCode: team._id,
+            teamId: team._id,
             email: userEmail,
         });
         await newMember.save({ session });
         
         // auto lock jika sudah 3 anggota
         const MAX_TEAM_MEMBERS = 3;
-        const memberCounter = await Member.countDocuments({ teamCode: team._id }).session(session);
+        const memberCounter = await Member.countDocuments({ teamId: team._id }).session(session);
 
         if (memberCounter >= MAX_TEAM_MEMBERS) {
             if (!team.isLock) {

--- a/backend/src/models/member.model.ts
+++ b/backend/src/models/member.model.ts
@@ -1,0 +1,32 @@
+import mongoose, {Document, Schema} from "mongoose";
+
+export interface IMember extends Document{
+    teamCode: mongoose.Types.ObjectId,
+    fullName?: string,
+    email: string,
+    dateOfBirth?: Date,
+    gender?: string,
+    whatsappNumber?: string,
+    institution?: string,
+    idCardUrl?: string,
+    twibbonLink?: string,
+    role?: string
+}
+
+const memberSchema = new Schema<IMember>({
+    teamCode: { type: Schema.Types.ObjectId, ref: 'Team', required: true},
+    fullName: { type: String},
+    email: { type: String, required: true },
+    dateOfBirth: { type: Date },
+    gender: { type: String },
+    whatsappNumber: { type: String },
+    institution: { type: String },
+    idCardUrl: { type: String },
+    twibbonLink: { type: String },
+    role: { type: String }
+})
+
+memberSchema.index({ teamCode: 1, email: 1 }, { unique: true });
+
+const Member = mongoose.model<IMember>('Member', memberSchema);
+export default Member;

--- a/backend/src/models/member.model.ts
+++ b/backend/src/models/member.model.ts
@@ -1,7 +1,7 @@
 import mongoose, {Document, Schema} from "mongoose";
 
 export interface IMember extends Document{
-    teamCode: mongoose.Types.ObjectId,
+    teamId: mongoose.Types.ObjectId,
     fullName?: string,
     email: string,
     dateOfBirth?: Date,
@@ -14,7 +14,7 @@ export interface IMember extends Document{
 }
 
 const memberSchema = new Schema<IMember>({
-    teamCode: { type: Schema.Types.ObjectId, ref: 'Team', required: true},
+    teamId: { type: Schema.Types.ObjectId, ref: 'Team', required: true},
     fullName: { type: String},
     email: { type: String, required: true },
     dateOfBirth: { type: Date },
@@ -26,7 +26,7 @@ const memberSchema = new Schema<IMember>({
     role: { type: String }
 })
 
-memberSchema.index({ teamCode: 1, email: 1 }, { unique: true });
+memberSchema.index({ teamId: 1, email: 1 }, { unique: true });
 
 const Member = mongoose.model<IMember>('Member', memberSchema);
 export default Member;

--- a/backend/src/models/team.membership.model.ts
+++ b/backend/src/models/team.membership.model.ts
@@ -1,16 +1,16 @@
 import mongoose, { Document, Schema } from "mongoose";
 
 export interface ITeamMembership extends Document {
-    teamCode: mongoose.Types.ObjectId;
+    teamId: mongoose.Types.ObjectId;
     userId: mongoose.Types.ObjectId;
 }
 
 const teamMembershipSchema = new Schema<ITeamMembership>({
-    teamCode: { type: Schema.Types.ObjectId, ref: 'Team', required: true },
+    teamId: { type: Schema.Types.ObjectId, ref: 'Team', required: true },
     userId: { type: Schema.Types.ObjectId, ref: 'User', required: true }
 });
 
-teamMembershipSchema.index({ teamCode: 1, userId: 1 }, { unique: true });
+teamMembershipSchema.index({ teamId: 1, userId: 1 }, { unique: true });
 
 const TeamMembership = mongoose.model<ITeamMembership>('TeamMembership', teamMembershipSchema);
 export default TeamMembership;

--- a/backend/src/models/team.membership.model.ts
+++ b/backend/src/models/team.membership.model.ts
@@ -1,0 +1,16 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+export interface ITeamMembership extends Document {
+    teamCode: mongoose.Types.ObjectId;
+    userId: mongoose.Types.ObjectId;
+}
+
+const teamMembershipSchema = new Schema<ITeamMembership>({
+    teamCode: { type: Schema.Types.ObjectId, ref: 'Team', required: true },
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true }
+});
+
+teamMembershipSchema.index({ teamCode: 1, userId: 1 }, { unique: true });
+
+const TeamMembership = mongoose.model<ITeamMembership>('TeamMembership', teamMembershipSchema);
+export default TeamMembership;

--- a/backend/src/models/team.model.ts
+++ b/backend/src/models/team.model.ts
@@ -1,0 +1,22 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+export interface ITeam extends Document{
+    teamCode: string,
+    teamName: string,
+    paymentProofUrl?: string,
+    isPay: boolean,
+    isLock: boolean,
+    isQualified: boolean
+}
+
+const teamSchema = new Schema<ITeam>({
+    teamCode: { type: String, required: true, unique: true },
+    teamName: { type: String, required: true },
+    paymentProofUrl: { type: String },
+    isPay: { type: Boolean, default: false },
+    isLock: { type: Boolean, default: false },
+    isQualified: { type: Boolean, default: false }
+})
+
+const Team = mongoose.model<ITeam>('Team', teamSchema);
+export default Team;

--- a/backend/src/routes/event.route.ts
+++ b/backend/src/routes/event.route.ts
@@ -1,9 +1,10 @@
-import express from 'express';
+import express, { RequestHandler } from 'express';
 import { authenticationToken } from '../middleware/auth.middleware';
-import { registerForEvent } from '../controllers/event.controller';
+import { registerForEvent, joinTeam } from '../controllers/event.controller';
 
 const router = express.Router();
 
-router.post('/register', authenticationToken, registerForEvent);
+router.post('/register', authenticationToken, registerForEvent as RequestHandler);
+router.post('/join', authenticationToken, joinTeam as RequestHandler);
 
 export default router;


### PR DESCRIPTION
1) Membuat schema sesuai ERD untuk event register,

Model yang dibuat:
  - member.model.ts
  - team.model.ts
  - team.membership.model.ts

2) Membuat function untuk register event dengan data sesuai dengan UI dan requirement, dengan flow seperti berikut:
  - User Register lalu Login
  - System keep token dan menyimpannya
  - Ketika user ingin register event, muncul beberapa requirement data yang wajib dimasukan untuk kelengkapan data menggunakan endpoint POST: [ **{{base_url}}/api/events/register** ], wajib memasukan Bearer Token yang sudah di keep. 
  
  Data yang wajib di input bisa dilihat dari raw body json ini:
  
  {
    "teamName": "Nama Tim",
    "paymentProofUrl": null, // default
    "teamMembers": [
      {
        "fullName": "Nama Anggota 1", // Nama lengkap, berbeda dengan name di user.model.ts
        "email": "anggota1@email.com",
        "dateOfBirth": "1999-01-01",
        "whatsappNumber": "081234567890",
        "institution": "Universitas A",
        "idCardUrl": "https://example.com/id-card-1.jpg",
        "twibbonLink": null,
        "role": "Ketua"
      }
  ]
}

3) Membuat function untuk join tim yang sudah di buat dengan menggunakan endpoint POST: [ **{{base_url}}/api/events/join** ], wajib memasukan Bearer Token. 

  Data yang dimasukan di raw body json:
  
  {
    "teamCode": "231944"
  }

note: 
- Endpoint events/join sudah menggunakan validasi ketika last member join a.k.a member ke-3, secara otomatis team  terkunci (isLock -> true).
- Jangan lupa configurasi untuk MongoDB replica set