### PR TITLE
feat(be-endpoint): add /event/mine

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -21,7 +21,7 @@ app.use(morgan('dev'));
 app.use('/api', authRoutes);
 
 app.use('/api/dashboard', dashboardRoutes);
-app.use('/api/events', eventRoutes);
+app.use('/api/event', eventRoutes);
 
 app.get('/', (req: Request, res: Response) => {
   res.status(200).json({ message: 'Berhasil masuk API BSLC' });

--- a/backend/src/routes/event.route.ts
+++ b/backend/src/routes/event.route.ts
@@ -1,10 +1,11 @@
 import express, { RequestHandler } from 'express';
 import { authenticationToken } from '../middleware/auth.middleware';
-import { registerForEvent, joinTeam } from '../controllers/event.controller';
+import { registerForEvent, joinTeam, getMyTeam } from '../controllers/event.controller';
 
 const router = express.Router();
 
 router.post('/register', authenticationToken, registerForEvent as RequestHandler);
 router.post('/join', authenticationToken, joinTeam as RequestHandler);
+router.get('/mine', authenticationToken, getMyTeam as RequestHandler); 
 
 export default router;


### PR DESCRIPTION
## Pull Request: [BE] Endpoint /event/mine to Get Team Data via JWT
### How to Test

1.  Ensure you have a valid JWT token for a registered user.
2.  **Scenario 1: User is in a team**
    - Using an authenticated request (e.g., in Postman with the Bearer Token), send a `GET` request to `/api/event/mine`.
    - **Expected Result:** A `200 OK` status with a JSON body containing the `team` object and a `members` array.
    ```json
    {
        "team": {
            "_id": "68876ba41371c8cbb8b48c90",
            "teamCode": "123456",
            "teamName": "Saleh's Team",
            // ... other team fields
        },
        "members": [
            {
                "_id": "...",
                "name": "saleh",
                "email": "saleh@gmail.com",
                "teamId": "68876ba41371c8cbb8b48c90"
            },
            // ... other members
        ]
    }
    ```
3.  **Scenario 2: User is not in a team**
    - Use a JWT token for a user that has not joined or created a team.
    - Send a `GET` request to `/api/event/mine`.
    - **Expected Result:** A `404 Not Found` status with the following JSON body:
    ```json
    {
        "message": "Kamu belum tergabung dalam tim manapun."
    }
    ```

